### PR TITLE
feat: Dynamic homepage stats via /api/stats

### DIFF
--- a/app/api/stats/route.ts
+++ b/app/api/stats/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+import { db } from "@/db/drizzle";
+import { campaignTable, paymentTable } from "@/db/schema";
+import { and, eq, sql, count, sum } from "drizzle-orm";
+
+export async function GET() {
+  try {
+    // Aggregate counts and sums
+    const [campaignsCountRow] = await db
+      .select({ total: count(campaignTable.id) })
+      .from(campaignTable);
+
+    const [completedCampaignsRow] = await db
+      .select({ total: count(campaignTable.id) })
+      .from(campaignTable)
+      .where(eq(campaignTable.status, "completed"));
+
+    const [totalRaisedRow] = await db
+      .select({ total: sum(campaignTable.amountReceived) })
+      .from(campaignTable);
+
+    const [donorsCountRow] = await db
+      .select({ total: sql<number>`COUNT(DISTINCT ${paymentTable.userId})` })
+      .from(paymentTable);
+
+    const totalCampaigns = Number(campaignsCountRow?.total ?? 0);
+    const completedCampaigns = Number(completedCampaignsRow?.total ?? 0);
+    const totalRaised = Number(totalRaisedRow?.total ?? 0);
+    const donorsCount = Number(donorsCountRow?.total ?? 0);
+
+    const successRate = totalCampaigns > 0 ? (completedCampaigns / totalCampaigns) * 100 : 0;
+
+    return NextResponse.json(
+      {
+        ok: true,
+        data: {
+          successfulCampaigns: completedCampaigns,
+          raised: totalRaised,
+          happyDonors: donorsCount,
+          successRate,
+        },
+      },
+      { status: 200 }
+    );
+  } catch (error) {
+    if (process.env.NODE_ENV === "development") console.error("/api/stats error", error);
+    return NextResponse.json({ ok: false, message: "Internal server error" }, { status: 500 });
+  }
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,12 @@ import { api } from "@/lib/api/api"
 
 export default function HomePage() {
   const [data, setData] = useState<Campaign[]>([])
+  const [statsData, setStatsData] = useState<{
+    successfulCampaigns: number
+    raised: number
+    happyDonors: number
+    successRate: number
+  } | null>(null)
 
   useEffect(() => {
     const getCampaign = async () => {
@@ -34,6 +40,19 @@ export default function HomePage() {
     }
 
     getCampaign()
+  }, [])
+
+  useEffect(() => {
+    const getStats = async () => {
+      try {
+        const res = await fetch("/api/stats", { cache: "no-store" })
+        const json = await res.json()
+        if (json?.ok) setStatsData(json.data)
+      } catch (e) {
+        // leave stats as null on failure
+      }
+    }
+    getStats()
   }, [])
 
   const howItWorksSteps = [
@@ -63,11 +82,31 @@ export default function HomePage() {
     },
   ]
 
+  const numberFmt = new Intl.NumberFormat(undefined)
+  const currencyFmt = new Intl.NumberFormat(undefined, { style: "currency", currency: "SLE", maximumFractionDigits: 0 })
+  const percentFmt = new Intl.NumberFormat(undefined, { style: "percent", maximumFractionDigits: 0 })
+
   const stats = [
-    { value: "500+", label: "Successful Campaigns", icon: Award },
-    { value: "NLe 2.5B+", label: "Raised for Communities", icon: TrendingUp },
-    { value: "50K+", label: "Happy Donors", icon: Users },
-    { value: "98%", label: "Success Rate", icon: Star },
+    {
+      value: statsData ? numberFmt.format(statsData.successfulCampaigns) : "—",
+      label: "Successful Campaigns",
+      icon: Award,
+    },
+    {
+      value: statsData ? `${currencyFmt.format(statsData.raised)}` : "—",
+      label: "Raised for Communities",
+      icon: TrendingUp,
+    },
+    {
+      value: statsData ? `${numberFmt.format(statsData.happyDonors)}` : "—",
+      label: "Happy Donors",
+      icon: Users,
+    },
+    {
+      value: statsData ? `${percentFmt.format(statsData.successRate / 100)}` : "—",
+      label: "Success Rate",
+      icon: Star,
+    },
   ]
 
   const features = [
@@ -244,7 +283,11 @@ export default function HomePage() {
                 <div className="w-12 h-12 gradient-bg rounded-xl mx-auto mb-4 flex items-center justify-center group-hover:scale-110 transition-transform">
                   <stat.icon className="w-6 h-6 text-white" />
                 </div>
-                <p className="text-3xl lg:text-4xl font-bold gradient-text mb-2">{stat.value}</p>
+                {statsData ? (
+                  <p className="text-3xl lg:text-4xl font-bold gradient-text mb-2">{stat.value}</p>
+                ) : (
+                  <div className="h-8 w-24 mx-auto mb-2 rounded bg-slate-200 animate-pulse" />
+                )}
                 <p className="text-slate-600">{stat.label}</p>
               </div>
             ))}


### PR DESCRIPTION
Implements dynamic statistics on the homepage by introducing a new public endpoint at `/api/stats` and wiring `app/page.tsx` to fetch and render the values with a loading skeleton.\n\n- Adds `app/api/stats/route.ts` aggregating platform metrics from the database (successful campaigns, total raised, unique donors, success rate).\n- Replaces hardcoded stats in `app/page.tsx` with fetched values; adds skeleton UI while loading.\n\nCloses #43