### PR TITLE
feat: Reusable EmptyState component across app

### DIFF
--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -9,6 +9,7 @@ import { api } from "@/lib/api/api"
 import type { CampaignDetails, CombinedUserData } from "@/types/api"
 import Link from "next/link"
 import { ShareModal } from "@/components/share-modal"
+import { EmptyState } from "@/components/empty-state"
 import { toast, Toaster } from "react-hot-toast"
 
 export default function CampaignDetailPage() {
@@ -483,9 +484,10 @@ export default function CampaignDetailPage() {
                     </div>
                   ))
                 ) : (
-                  <div className="text-center py-4">
-                    <div className="text-sm text-slate-500">No recent donors yet</div>
-                  </div>
+                  <EmptyState
+                    title="No recent donors yet"
+                    description="Be the first to support this campaign."
+                  />
                 )}
               </div>
             </div>
@@ -1111,9 +1113,10 @@ export default function CampaignDetailPage() {
                     </div>
                   ))
                 ) : (
-                  <div className="text-center py-4">
-                    <div className="text-sm text-slate-500">No recent donors yet</div>
-                  </div>
+                  <EmptyState
+                    title="No recent donors yet"
+                    description="Share this campaign to help it gain traction."
+                  />
                 )}
               </div>
 

--- a/app/campaigns/page.tsx
+++ b/app/campaigns/page.tsx
@@ -9,6 +9,7 @@ import { Badge } from "../../components/ui/badge"
 import { Card, CardContent } from "../../components/ui/card"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../components/ui/select"
 import { api } from "@/lib/api/api"
+import { EmptyState } from "@/components/empty-state"
 import { Campaign } from "@/types/api"
 
 const categories = [
@@ -388,16 +389,11 @@ export default function CampaignsPage() {
 
         {/* Regular Campaigns */}
         {displayedCampaigns.length === 0 ? (
-          <div className="text-center py-12 sm:py-16">
-            <div className="w-20 h-20 sm:w-24 sm:h-24 bg-slate-200 rounded-full mx-auto mb-6 flex items-center justify-center">
-              <Search className="w-10 h-10 sm:w-12 sm:h-12 text-slate-400" />
-            </div>
-            <h3 className="text-xl sm:text-2xl font-semibold text-slate-900 mb-2">No campaigns found</h3>
-            <p className="text-slate-600 mb-6">Try adjusting your search terms or filters</p>
-            <Button onClick={clearAllFilters} className="bg-blue-600 hover:bg-blue-700">
-              Clear All Filters
-            </Button>
-          </div>
+          <EmptyState
+            title="No campaigns found"
+            description="Try adjusting your search terms or filters"
+            action={<Button onClick={clearAllFilters} className="bg-blue-600 hover:bg-blue-700">Clear All Filters</Button>}
+          />
         ) : (
           <div>
             {featuredCampaigns.length > 0 && (

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -24,6 +24,7 @@ import { useUser } from "@clerk/nextjs"
 import type { Dashboard } from "@/types/api"
 import { api } from "@/lib/api/api"
 import CashoutModal from "@/components/cashout-modal"
+import { EmptyState } from "@/components/empty-state"
 
 export default function CreatorDashboard() {
   const [data, setData] = useState<Dashboard>()
@@ -229,15 +230,17 @@ export default function CreatorDashboard() {
 
   if (!data) {
     return (
-      <div className="min-h-screen flex items-center justify-center">
-        <div className="text-center">
-          <h1 className="text-2xl sm:text-3xl md:text-4xl font-bold text-slate-900 mb-4">No Data Available</h1>
-          <p className="text-lg sm:text-xl text-slate-600">We couldn&apos;t load your dashboard data</p>
-          <Link href="/create-campaign" className="btn-primary mt-4 inline-flex items-center">
-            <Plus className="w-4 h-4 mr-2" />
-            Create Your First Campaign
-          </Link>
-        </div>
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <EmptyState
+          title="No data available"
+          description="We couldn't load your dashboard data. You can start by creating your first campaign."
+          action={
+            <Link href="/create-campaign" className="btn-primary mt-2 inline-flex items-center">
+              <Plus className="w-4 h-4 mr-2" />
+              Create Your First Campaign
+            </Link>
+          }
+        />
       </div>
     )
   }
@@ -409,9 +412,10 @@ export default function CreatorDashboard() {
                     )}
                   </>
                 ) : (
-                  <div className="text-center py-8">
-                    <p className="text-slate-500">No recent activity</p>
-                  </div>
+                  <EmptyState
+                    title="No recent activity"
+                    description="When there are donations, comments, or updates, they'll appear here."
+                  />
                 )}
               </div>
             </div>

--- a/components/empty-state.tsx
+++ b/components/empty-state.tsx
@@ -1,0 +1,40 @@
+"use client"
+
+import Image from "next/image"
+import { ReactNode } from "react"
+import { Button } from "@/components/ui/button"
+
+export function EmptyState({
+  illustration,
+  title,
+  description,
+  action,
+}: {
+  illustration?: string
+  title: string
+  description?: string
+  action?: ReactNode
+}) {
+  return (
+    <div className="text-center py-12 sm:py-16 bg-white/60 rounded-2xl border border-slate-200">
+      {illustration && (
+        <div className="mx-auto mb-6">
+          <Image src={illustration} alt={title} width={200} height={200} />
+        </div>
+      )}
+      <h3 className="text-xl sm:text-2xl font-semibold text-slate-900 mb-2">{title}</h3>
+      {description && (
+        <p className="text-slate-600 max-w-md mx-auto mb-6">{description}</p>
+      )}
+      {action ? action : null}
+    </div>
+  )
+}
+
+export function EmptyActionButton({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <Button asChild>
+      <a href={href}>{children}</a>
+    </Button>
+  )
+}


### PR DESCRIPTION
Introduces a reusable EmptyState component and replaces generic empty messages across key views.\n\n- Adds  for on-brand empty screens with optional CTA\n- Integrates in , , and  (recent donors)\n\nCloses #42