### PR TITLE
refactor: Standardize button hierarchy + improve mobile card info order

### DIFF
--- a/components/campaign-card.tsx
+++ b/components/campaign-card.tsx
@@ -199,7 +199,7 @@ export default function CampaignCard({ campaign, featured = false, viewMode = "g
             </div>
           </div>
 
-          <div className="absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-2 group-hover:translate-y-0">
+          <div className="hidden sm:block absolute top-3 right-3 opacity-0 group-hover:opacity-100 transition-all duration-300 transform translate-y-2 group-hover:translate-y-0">
             <div className="flex gap-2">
               <Button
                 size="sm"
@@ -322,7 +322,8 @@ export default function CampaignCard({ campaign, featured = false, viewMode = "g
             </Button>
           ) : (
             <Button
-              className="w-full bg-gradient-to-r from-blue-600 to-purple-600 hover:from-blue-700 hover:to-purple-700 text-white border-0 shadow-lg hover:shadow-xl transition-all"
+              variant="primary"
+              className="w-full shadow-lg hover:shadow-xl transition-all"
               onClick={(e) => {
                 e.preventDefault()
                 e.stopPropagation()

--- a/components/ui/button.tsx
+++ b/components/ui/button.tsx
@@ -18,6 +18,9 @@ const buttonVariants = cva(
           "bg-secondary text-secondary-foreground hover:bg-secondary/80",
         ghost: "hover:bg-accent hover:text-accent-foreground",
         link: "text-primary underline-offset-4 hover:underline",
+        // Standardized aliases
+        primary: "bg-primary text-primary-foreground hover:bg-primary/90",
+        tertiary: "hover:bg-accent hover:text-accent-foreground",
       },
       size: {
         default: "h-10 px-4 py-2",


### PR DESCRIPTION
Establishes consistent button variants and improves mobile information hierarchy for campaign cards.\n\n- Adds alias variants (primary/secondary/tertiary) to \n- Uses  for key CTAs; keeps existing variants backward-compatible\n- Hides hover-only action buttons on mobile in  to prioritize info over actions\n\nAddresses #40 and #15