### PR TITLE
feat(home): modern stats section with StatCard + consistent Raised/Goal

### DIFF
--- a/app/campaigns/[id]/page.tsx
+++ b/app/campaigns/[id]/page.tsx
@@ -398,6 +398,11 @@ export default function CampaignDetailPage() {
                 <div className="text-sm text-slate-500">
                   Goal: {formatCurrency(campaign.fundingGoal)}
                 </div>
+                <div className="mt-2">
+                  <span className="inline-flex items-center text-xs px-2 py-1 rounded-full bg-indigo-50 text-indigo-700 border border-indigo-100">
+                    Remaining: {formatCurrency(Math.max(0, campaign.fundingGoal - campaign.amountReceived))}
+                  </span>
+                </div>
               </div>
 
               <div className="grid grid-cols-2 gap-4 mb-4">
@@ -1056,6 +1061,11 @@ export default function CampaignDetailPage() {
                 </div>
                 <div className="text-sm text-slate-500">
                   Goal: {formatCurrency(campaign.fundingGoal)}
+                </div>
+                <div className="mt-2">
+                  <span className="inline-flex items-center text-xs px-2 py-1 rounded-full bg-indigo-50 text-indigo-700 border border-indigo-100">
+                    Remaining: {formatCurrency(Math.max(0, campaign.fundingGoal - campaign.amountReceived))}
+                  </span>
                 </div>
               </div>
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,6 +20,7 @@ import {
 import CampaignCard from "../components/campaign-card"
 import { Button } from "../components/ui/button"
 import { Badge } from "../components/ui/badge"
+import { StatCard } from "@/components/stat-card"
 import type { Campaign } from "@/types/api"
 import { useEffect, useState } from "react"
 import { api } from "@/lib/api/api"
@@ -276,20 +277,7 @@ export default function HomePage() {
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-6">
             {stats.map((stat, index) => (
-              <div
-                key={index}
-                className="text-center p-8 bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all duration-300 border border-ocean-100/50 group"
-              >
-                <div className="w-12 h-12 gradient-bg rounded-xl mx-auto mb-4 flex items-center justify-center group-hover:scale-110 transition-transform">
-                  <stat.icon className="w-6 h-6 text-white" />
-                </div>
-                {statsData ? (
-                  <p className="text-3xl lg:text-4xl font-bold gradient-text mb-2">{stat.value}</p>
-                ) : (
-                  <div className="h-8 w-24 mx-auto mb-2 rounded bg-slate-200 animate-pulse" />
-                )}
-                <p className="text-slate-600">{stat.label}</p>
-              </div>
+              <StatCard key={index} icon={stat.icon} value={String(stat.value)} label={stat.label} />
             ))}
           </div>
         </div>

--- a/components/campaign-card.tsx
+++ b/components/campaign-card.tsx
@@ -267,6 +267,18 @@ export default function CampaignCard({ campaign, featured = false, viewMode = "g
               <Progress value={progress} className="h-3 bg-gray-100" />
             </div>
 
+            {/* Amounts: Raised vs Goal */}
+            <div className="grid grid-cols-2 gap-4 text-sm mt-2">
+              <div>
+                <p className="text-slate-600">Raised</p>
+                <p className="font-semibold text-slate-900">{formatAmount(campaign.amountReceived)}</p>
+              </div>
+              <div className="text-right">
+                <p className="text-slate-600">Goal</p>
+                <p className="font-semibold text-slate-900">{formatAmount(campaign.fundingGoal)}</p>
+              </div>
+            </div>
+
             {/* Creator and Location */}
             <div className="flex items-center justify-between pt-2 border-t border-slate-100">
               <div className="flex items-center gap-2">

--- a/components/stat-card.tsx
+++ b/components/stat-card.tsx
@@ -1,0 +1,27 @@
+"use client"
+
+import { ElementType } from "react"
+
+export function StatCard({
+  icon: Icon,
+  value,
+  label,
+}: {
+  icon: ElementType
+  value: string
+  label: string
+}) {
+  return (
+    <div className="text-center p-8 bg-white rounded-2xl shadow-sm hover:shadow-lg transition-all duration-300 border border-ocean-100/50 group">
+      <div className="w-12 h-12 gradient-bg rounded-xl mx-auto mb-4 flex items-center justify-center group-hover:scale-110 transition-transform">
+        <Icon className="w-6 h-6 text-white" />
+      </div>
+      {value ? (
+        <p className="text-3xl lg:text-4xl font-bold gradient-text mb-2">{value}</p>
+      ) : (
+        <div className="h-8 w-24 mx-auto mb-2 rounded bg-slate-200 animate-pulse" />
+      )}
+      <p className="text-slate-600">{label}</p>
+    </div>
+  )
+}


### PR DESCRIPTION
- Add reusable 
- Use StatCard in homepage  for live KPIs from /api/stats
- Keep campaign cards using Raised/Goal labels for clarity

Screenshots included.